### PR TITLE
Use java.util.function.Function

### DIFF
--- a/functions-api/pom.xml
+++ b/functions-api/pom.xml
@@ -34,6 +34,10 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+    </dependency>
 
     <!-- testing -->
     <dependency>

--- a/functions-api/src/main/java/io/jenkins/functions/Logger.java
+++ b/functions-api/src/main/java/io/jenkins/functions/Logger.java
@@ -1,0 +1,8 @@
+package io.jenkins.functions;
+
+import java.io.PrintStream;
+
+public interface Logger {
+    PrintStream out();
+    PrintStream err();
+}

--- a/functions-api/src/main/java/io/jenkins/functions/Result.java
+++ b/functions-api/src/main/java/io/jenkins/functions/Result.java
@@ -1,0 +1,7 @@
+package io.jenkins.functions;
+
+public enum Result {
+    SUCCESS,
+    FAILURE,
+    UNSTABLE
+}

--- a/functions-sample/src/main/java/io/jenkins/functions/sample/FunctionExample.java
+++ b/functions-sample/src/main/java/io/jenkins/functions/sample/FunctionExample.java
@@ -1,0 +1,39 @@
+package io.jenkins.functions.sample;
+
+import io.jenkins.functions.Argument;
+import io.jenkins.functions.Logger;
+import io.jenkins.functions.Result;
+import io.jenkins.functions.Step;
+
+import javax.inject.Inject;
+import java.util.function.Function;
+
+@Step
+public class FunctionExample implements Function<FunctionExample.Context, Result> {
+
+    @Inject
+    Logger logger;
+
+    @Override
+    public Result apply(Context context) {
+        Result result;
+        if (context.message == null) {
+            logger.err().println("<message> not provided");
+            result = Result.FAILURE;
+        } else {
+            logger.out().println(String.format("Hello, %s", context.message));
+            result = Result.SUCCESS;
+        }
+        return result;
+    }
+
+    public static class Context {
+
+        @Argument
+        public final String message;
+
+        public Context(String message) {
+            this.message = message;
+        }
+    }
+}


### PR DESCRIPTION
@jstrachan what if we used `java.util.function.Function` so that a valid Pipeline function was something like the one in this PR? 

This introduces a `Logger` interface so we can redirect the stdout/stderr for the Pipeline log and a `Result` status that matches the valid states of a step. 

